### PR TITLE
Update manifest.webapp

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -30,9 +30,23 @@
     }
   },
   "locales": {
-    "en": {
-      "name": "Checklists",
-      "description": "Create checklists"
+    "eo": {
+      "name": "Markolistoj",
+      "description": "Aplikaĵo por krei markolistojn"
+      "permissions": {
+        "device-storage:sdcard": {
+          "description": "Por konservi kaj ŝargi markolistojn"
+        }
+      }
+    },
+    "it": {
+      "name": "Liste",
+      "description": "App per creare liste"
+      "permissions": {
+        "device-storage:sdcard": {
+          "description": "Per salvare e caricare le liste"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
- Fixed error ("en" is the default one, as it is claimed by "default_locale")
- Added Italian (it) and Esperanto (eo) localization
